### PR TITLE
feat: add pearson vue folder to the image

### DIFF
--- a/tutornelc_extensions/patches/openedx-dockerfile-post-python-requirements
+++ b/tutornelc_extensions/patches/openedx-dockerfile-post-python-requirements
@@ -8,4 +8,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 ENV AWS_ACCESS_KEY_ID={{ NELC_EXTENSIONS_AWS_ACCESS_KEY }}
 ENV AWS_SECRET_ACCESS_KEY={{ NELC_EXTENSIONS_AWS_SECRET_ACCESS_KEY }}
 ENV AWS_DEFAULT_REGION={{ NELC_EXTENSIONS_AWS_DEFAULT_REGION }}
+{% if NELC_EXTENSIONS_PEARSON_VUE_API_CERT_INCLUDE %}
+RUN mkdir -p /pearson_vue/api_cert \
+    && /openedx/aws-cli/v2/current/bin/aws s3 sync s3://{{ NELC_EXTENSIONS_PEARSON_VUE_S3_BUCKET }}/api_cert/ /pearson_vue/api_cert/
+{% endif %}
 {% endif %}

--- a/tutornelc_extensions/patches/openedx-dockerfile-pre-assets
+++ b/tutornelc_extensions/patches/openedx-dockerfile-pre-assets
@@ -6,3 +6,7 @@ RUN pip install openedx-atlas=={{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_OPENEDX_
     && cd {{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_PATH }} \
     && django-admin compilemessages -v1
 {% endif %}
+
+{% if NELC_EXTENSIONS_USE_AWS_CLI and NELC_EXTENSIONS_PEARSON_VUE_API_CERT_INCLUDE %}
+COPY --chown=app:app --from=python-requirements /pearson_vue /pearson_vue
+{% endif %}


### PR DESCRIPTION
# Description

to use it you need aws cli configuration vars and NELC_EXTENSIONS_PEARSON_VUE_API_CERT_INCLUDE
in true with NELC_EXTENSIONS_PEARSON_VUE_S3_BUCKET

## Test

CHeck the image generated has the pearson_vue folder.
![image](https://github.com/nelc/tutor-contrib-nelc-extensions/assets/51926076/938ce926-628a-493d-8380-fe05cd020536)

