### PR TITLE
fix: ensure js translation overrides are included in compiled js translations

### DIFF
--- a/tutornelc_extensions/patches/openedx-dockerfile-pre-assets
+++ b/tutornelc_extensions/patches/openedx-dockerfile-pre-assets
@@ -3,10 +3,10 @@ RUN pip install openedx-atlas=={{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_OPENEDX_
     && mkdir -p {{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_LOCALE_PATH }} \
     && atlas pull --repository='{{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_ATLAS_REPOSITORY }}' --revision='{{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_ATLAS_REVISION }}' {{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_ATLAS_OPTIONS }} \
     {{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_ATLAS_LOCALE_PATH }}:{{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_LOCALE_PATH }} \
-    && cd {{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_PATH }} \
-    && django-admin compilemessages -v1 \
     && ./manage.py lms --settings=tutor.i18n compilejsi18n \
-    && ./manage.py cms --settings=tutor.i18n compilejsi18n
+    && ./manage.py cms --settings=tutor.i18n compilejsi18n  \
+    && cd {{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_PATH }} \
+    && django-admin compilemessages -v1
 {% endif %}
 
 {% if NELC_EXTENSIONS_USE_AWS_CLI and NELC_EXTENSIONS_PEARSON_VUE_API_CERT_INCLUDE %}

--- a/tutornelc_extensions/patches/openedx-dockerfile-pre-assets
+++ b/tutornelc_extensions/patches/openedx-dockerfile-pre-assets
@@ -4,7 +4,9 @@ RUN pip install openedx-atlas=={{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_OPENEDX_
     && atlas pull --repository='{{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_ATLAS_REPOSITORY }}' --revision='{{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_ATLAS_REVISION }}' {{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_ATLAS_OPTIONS }} \
     {{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_ATLAS_LOCALE_PATH }}:{{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_LOCALE_PATH }} \
     && cd {{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_PATH }} \
-    && django-admin compilemessages -v1
+    && django-admin compilemessages -v1 \
+    && ./manage.py lms --settings=tutor.i18n compilejsi18n \
+    && ./manage.py cms --settings=tutor.i18n compilejsi18n
 {% endif %}
 
 {% if NELC_EXTENSIONS_USE_AWS_CLI and NELC_EXTENSIONS_PEARSON_VUE_API_CERT_INCLUDE %}


### PR DESCRIPTION
Otherwise js translations aren't overridden