### PR TITLE
fix: apt update for unzip

### DIFF
--- a/tutornelc_extensions/patches/openedx-dockerfile-post-python-requirements
+++ b/tutornelc_extensions/patches/openedx-dockerfile-post-python-requirements
@@ -1,7 +1,8 @@
 {% if NELC_EXTENSIONS_USE_AWS_CLI %}
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt install unzip \
+  && apt update \
+  && apt install unzip \
   && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
   && unzip awscliv2.zip \
   && ./aws/install --bin-dir /openedx/bin --install-dir /openedx/aws-cli && rm -r aws awscliv2.zip

--- a/tutornelc_extensions/patches/openedx-dockerfile-post-python-requirements
+++ b/tutornelc_extensions/patches/openedx-dockerfile-post-python-requirements
@@ -1,7 +1,7 @@
 {% if NELC_EXTENSIONS_USE_AWS_CLI %}
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-  && apt update \
+     apt update \
   && apt install unzip -y \
   && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
   && unzip awscliv2.zip \

--- a/tutornelc_extensions/patches/openedx-dockerfile-post-python-requirements
+++ b/tutornelc_extensions/patches/openedx-dockerfile-post-python-requirements
@@ -2,7 +2,7 @@
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
   && apt update \
-  && apt install unzip \
+  && apt install unzip -y \
   && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
   && unzip awscliv2.zip \
   && ./aws/install --bin-dir /openedx/bin --install-dir /openedx/aws-cli && rm -r aws awscliv2.zip


### PR DESCRIPTION
# Description
Fix builts, start failing due unzip package is not located.

## Before
Building the image fails
![2024-07-10_07-59](https://github.com/nelc/tutor-contrib-nelc-extensions/assets/51926076/2971701c-fcf4-4c1b-a8fb-18b467bbc6db)

## After
The images built works.
![2024-07-10_08-02](https://github.com/nelc/tutor-contrib-nelc-extensions/assets/51926076/a3e9cb2f-fc3a-4ce9-ae1b-aec985a8805e)
