### PR TITLE
feat: add aws mysql ssl ca

### DIFF
--- a/tutornelc_extensions/patches/mysql-ssl-ca-settings
+++ b/tutornelc_extensions/patches/mysql-ssl-ca-settings
@@ -1,0 +1,7 @@
+{% if NELC_EXTENSIONS_MYSQL_SSL_CA_CONFIG %}
+# ssl-ca configuration
+DATABASES["default"]["OPTIONS"]["ssl_mode"] = "VERIFY_CA"
+DATABASES["default"]["OPTIONS"]["ssl"] = {
+    "ca": "{{ NELC_EXTENSIONS_MYSQL_SSL_CA_PATH} }/ssl_ca.pem"
+}
+{% endif %}

--- a/tutornelc_extensions/patches/openedx-dockerfile-post-python-requirements
+++ b/tutornelc_extensions/patches/openedx-dockerfile-post-python-requirements
@@ -14,3 +14,12 @@ RUN mkdir -p /pearson_vue/api_cert \
     && /openedx/aws-cli/v2/current/bin/aws s3 sync s3://{{ NELC_EXTENSIONS_PEARSON_VUE_S3_BUCKET }}/api_cert/ /pearson_vue/api_cert/
 {% endif %}
 {% endif %}
+
+
+{% if NELC_EXTENSIONS_MYSQL_SSL_CA_PULL %}
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+     apt update \
+    && mkdir -p {{ NELC_EXTENSIONS_MYSQL_SSL_CA_PATH }} \
+    && curl -o {{ NELC_EXTENSIONS_MYSQL_SSL_CA_PATH }}/ssl_ca.pem {{ NELC_EXTENSIONS_MYSQL_SSL_CA_URL }}
+{% endif %}

--- a/tutornelc_extensions/patches/openedx-dockerfile-pre-assets
+++ b/tutornelc_extensions/patches/openedx-dockerfile-pre-assets
@@ -10,3 +10,7 @@ RUN pip install openedx-atlas=={{ NELC_EXTENSIONS_TRANSLATION_OVERRIDES_OPENEDX_
 {% if NELC_EXTENSIONS_USE_AWS_CLI and NELC_EXTENSIONS_PEARSON_VUE_API_CERT_INCLUDE %}
 COPY --chown=app:app --from=python-requirements /pearson_vue /pearson_vue
 {% endif %}
+
+{% if NELC_EXTENSIONS_MYSQL_SSL_CA_PULL %}
+COPY --chown=app:app --from=python-requirements {{ NELC_EXTENSIONS_MYSQL_SSL_CA_PATH }} {{ NELC_EXTENSIONS_MYSQL_SSL_CA_PATH }}
+{% endif %}

--- a/tutornelc_extensions/plugin.py
+++ b/tutornelc_extensions/plugin.py
@@ -25,6 +25,13 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ("NELC_EXTENSIONS_TRANSLATION_OVERRIDES", True),
         ("NELC_EXTENSIONS_TRANSLATION_OVERRIDES_OPENEDX_ATLAS_VERSION", "0.6.0"),
         ("NELC_EXTENSIONS_USE_AWS_CLI", False),
+        ("NELC_EXTENSIONS_MYSQL_SSL_CA_PULL", True),
+        (
+            "NELC_EXTENSIONS_MYSQL_SSL_CA_URL",
+            "https://truststore.pki.rds.amazonaws.com/me-south-1/me-south-1-bundle.pem"
+        ),
+        ("NELC_EXTENSIONS_MYSQL_SSL_CA_PATH", "/mysql-ssl-ca"),
+        ("NELC_EXTENSIONS_MYSQL_SSL_CA_CONFIG", False),
     ]
 )
 


### PR DESCRIPTION
This add the ca for mysql client in the docker image.

This also has a short part for settings for the mysql in django openedx.

## Test

This was tested using this branch in nelc indexes https://github.com/nelc/tutor-plugin-indexes/pull/1 and then in a strain.
https://github.com/nelc/edx-platform-strains/pull/341

So the image was already created.

To test run the following
```
docker run -it  ednxops/distro-edunext-edxapp:nelp-v18.0.1-test-ssl-ca-extensions bash
ls -al /mysql-ssl-ca/
```
Check the cert is in the desired path
![image](https://github.com/user-attachments/assets/99c02892-d95d-4431-9b0f-0ae53913820a)
