### PR TITLE
feat: add ssl-cal for special deployments

### DIFF
--- a/tutornelc_extensions/patches/k8s-override
+++ b/tutornelc_extensions/patches/k8s-override
@@ -1,0 +1,31 @@
+{%- for deployment in NELC_EXTENSIONS_MYSQL_SSL_CA_EXTRA_DEPLOYMENTS_MOUNT %}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ deployment }}
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: fetch-ssl-ca
+        image: curlimages/curl
+        command:
+        - /bin/sh
+        - -c
+        - |
+          curl -o {{ NELC_EXTENSIONS_MYSQL_SSL_CA_PATH }}/ssl_ca.pem {{ NELC_EXTENSIONS_MYSQL_SSL_CA_URL }}
+        volumeMounts:
+        - name: mysql-ca-volume
+          mountPath: {{ NELC_EXTENSIONS_MYSQL_SSL_CA_PATH }}
+      containers:
+        - name: {{ deployment }}
+          volumeMounts:
+            - mountPath: {{ NELC_EXTENSIONS_MYSQL_SSL_CA_PATH }}
+              name: mysql-ca-volume
+              readOnly: true
+      volumes:
+        - name: mysql-ca-volume
+          emptyDir: {}
+---
+{%- endfor %}

--- a/tutornelc_extensions/plugin.py
+++ b/tutornelc_extensions/plugin.py
@@ -32,6 +32,7 @@ hooks.Filters.CONFIG_DEFAULTS.add_items(
         ),
         ("NELC_EXTENSIONS_MYSQL_SSL_CA_PATH", "/mysql-ssl-ca"),
         ("NELC_EXTENSIONS_MYSQL_SSL_CA_CONFIG", False),
+        ("NELC_EXTENSIONS_MYSQL_SSL_CA_EXTRA_DEPLOYMENTS_MOUNT", []),
     ]
 )
 


### PR DESCRIPTION
# Description

Sometimes the images built doesnt have the ssl-ca, in this case we could use this logic to added to the container that run that.

## Test
tested in stage using this PR:
https://github.com/nelc/manifest-sagar/pull/723
this creates the override like the following:

https://github.com/nelc/manifest-sagar/pull/723/commits/2fd5c4dbf811c2c349d4f37f7eb53ff4c6dfcd29#diff-31c51dc115f1fef146f14c0ae101d6e971bcf0f98daa6ca4c57b40cda56fbf3cR114

#### Results
 You could see how the init_container curl the ca
![Screenshot from 2025-01-28 15-28-20](https://github.com/user-attachments/assets/a2b76ed5-96ce-4381-94b2-25ccd438c276)




Init container ran succesfull
![2025-01-28_15-29](https://github.com/user-attachments/assets/e1283955-6735-42ac-bc48-221968b2900d)

Init logs of container show the curl process,

![2025-01-28_15-31](https://github.com/user-attachments/assets/07a0172e-abb3-4c6c-bacc-2fb27f29b868)

 and then discovery pod has the ssl-cal cert.

![Screenshot from 2025-01-28 15-31-46](https://github.com/user-attachments/assets/b42484cd-3c22-44f3-bb5c-4ff882f574aa)