### PR TITLE
feat: add ssl-ca settings via patches

### DIFF
--- a/tutornelc_extensions/patches/discovery-common-settings
+++ b/tutornelc_extensions/patches/discovery-common-settings
@@ -1,0 +1,3 @@
+{% if NELC_EXTENSIONS_MYSQL_SSL_CA_CONFIG and 'discovery' in NELC_EXTENSIONS_MYSQL_SSL_CA_EXTRA_DEPLOYMENTS_MOUNT%}
+{{ patch("mysql-ssl-ca-settings") }}
+{% endif %}

--- a/tutornelc_extensions/patches/discovery-common-settings
+++ b/tutornelc_extensions/patches/discovery-common-settings
@@ -1,3 +1,3 @@
-{% if NELC_EXTENSIONS_MYSQL_SSL_CA_CONFIG and 'discovery' in NELC_EXTENSIONS_MYSQL_SSL_CA_EXTRA_DEPLOYMENTS_MOUNT%}
+{% if 'discovery' in NELC_EXTENSIONS_MYSQL_SSL_CA_EXTRA_DEPLOYMENTS_MOUNT%}
 {{ patch("mysql-ssl-ca-settings") }}
 {% endif %}

--- a/tutornelc_extensions/patches/ecommerce-settings-common
+++ b/tutornelc_extensions/patches/ecommerce-settings-common
@@ -1,3 +1,3 @@
-{% if NELC_EXTENSIONS_MYSQL_SSL_CA_CONFIG and 'ecommerce' in NELC_EXTENSIONS_MYSQL_SSL_CA_EXTRA_DEPLOYMENTS_MOUNT%}
+{% if 'ecommerce' in NELC_EXTENSIONS_MYSQL_SSL_CA_EXTRA_DEPLOYMENTS_MOUNT%}
 {{ patch("mysql-ssl-ca-settings") }}
 {% endif %}

--- a/tutornelc_extensions/patches/ecommerce-settings-common
+++ b/tutornelc_extensions/patches/ecommerce-settings-common
@@ -1,0 +1,3 @@
+{% if NELC_EXTENSIONS_MYSQL_SSL_CA_CONFIG and 'ecommerce' in NELC_EXTENSIONS_MYSQL_SSL_CA_EXTRA_DEPLOYMENTS_MOUNT%}
+{{ patch("mysql-ssl-ca-settings") }}
+{% endif %}

--- a/tutornelc_extensions/patches/mysql-ssl-ca-settings
+++ b/tutornelc_extensions/patches/mysql-ssl-ca-settings
@@ -2,6 +2,6 @@
 # ssl-ca configuration
 DATABASES["default"]["OPTIONS"]["ssl_mode"] = "VERIFY_CA"
 DATABASES["default"]["OPTIONS"]["ssl"] = {
-    "ca": "{{ NELC_EXTENSIONS_MYSQL_SSL_CA_PATH} }/ssl_ca.pem"
+    "ca": "{{ NELC_EXTENSIONS_MYSQL_SSL_CA_PATH }}/ssl_ca.pem"
 }
 {% endif %}

--- a/tutornelc_extensions/patches/notes-settings
+++ b/tutornelc_extensions/patches/notes-settings
@@ -1,3 +1,3 @@
-{% if NELC_EXTENSIONS_MYSQL_SSL_CA_CONFIG and 'notes' in NELC_EXTENSIONS_MYSQL_SSL_CA_EXTRA_DEPLOYMENTS_MOUNT%}
+{% if 'notes' in NELC_EXTENSIONS_MYSQL_SSL_CA_EXTRA_DEPLOYMENTS_MOUNT%}
 {{ patch("mysql-ssl-ca-settings") }}
 {% endif %}

--- a/tutornelc_extensions/patches/notes-settings
+++ b/tutornelc_extensions/patches/notes-settings
@@ -1,0 +1,3 @@
+{% if NELC_EXTENSIONS_MYSQL_SSL_CA_CONFIG and 'notes' in NELC_EXTENSIONS_MYSQL_SSL_CA_EXTRA_DEPLOYMENTS_MOUNT%}
+{{ patch("mysql-ssl-ca-settings") }}
+{% endif %}

--- a/tutornelc_extensions/patches/openedx-common-settings
+++ b/tutornelc_extensions/patches/openedx-common-settings
@@ -1,0 +1,3 @@
+{% if NELC_EXTENSIONS_MYSQL_SSL_CA_CONFIG %}
+{{ patch("mysql-ssl-ca-settings") }}
+{% endif %}

--- a/tutornelc_extensions/patches/openedx-common-settings
+++ b/tutornelc_extensions/patches/openedx-common-settings
@@ -1,3 +1,1 @@
-{% if NELC_EXTENSIONS_MYSQL_SSL_CA_CONFIG %}
 {{ patch("mysql-ssl-ca-settings") }}
-{% endif %}


### PR DESCRIPTION
# Description
This add ca settings configuration for:
- openedx -> openedx-common-settings lms,cms,lms-worker,cms-worker...
- notes -> notes-settings
- discovery -> discovery-common-settings
- ecommerce -> ecommerce-settings-common

fix: } typo

chore: fix rename of ecom patch


## TEst

Tested in stage sagar with this branch jlc/mysql-ssl-ca-refactor

![image](https://github.com/user-attachments/assets/7ee2412c-4cb4-4e31-99ad-fd66c5569af6)
![Peek 2025-01-31 09-49](https://github.com/user-attachments/assets/e1748666-a314-40fb-9654-bc608db49df6)
